### PR TITLE
Add Dublin Core relation element attributes.

### DIFF
--- a/lib/json-generator.rb
+++ b/lib/json-generator.rb
@@ -549,6 +549,21 @@ def build_core_doc()
         end
     end
 
+    # Do we have a qualified relation element?
+    entry = "relation_rich".to_sym
+    @mets.xpath("//mets:dmdSec[@ID='DMD1']//dc:relation", @namespaces).each do |node|
+        if node.has_attribute? "type" and node.has_attribute? "identifier"
+            m = {
+                content: node.content.strip,
+                type: node["type"].strip,
+                identifier: node["identifier"].strip,
+            }
+            puts "#{entry}: #{m.to_json}"
+            core_doc[entry] ||= []
+            core_doc[entry] << m.to_json
+        end
+    end
+
     unless core_doc[:title].count == 0
         core_doc[:title_object] = core_doc[:title].first
     end


### PR DESCRIPTION
This checks for a dc:relation element with type and identifier attributes and records an encoded JSON string for each such element.

Example input (partial):

```xml
<dc:relation type="isPartOf" identifier="https://uky-edu.maps.arcgis.com/apps/instant/basic/index.html?appid=4cfd9d45422b479a9a78ed53d209cc94">1937 Fayette County Imagery Index</dc:relation>
```

Example output (partial):

```json
"relation_rich": [
    "{\"content\":\"1937 Fayette County Imagery Index\",\"type\":\"isPartOf\",\"identifier\":\"https://uky-edu.maps.arcgis.com/apps/instant/basic/index.html?appid=4cfd9d45422b479a9a78ed53d209cc94\"}"
]
```